### PR TITLE
fix: дать возможность публиковать миграции

### DIFF
--- a/src/TwoFactorServiceProvider.php
+++ b/src/TwoFactorServiceProvider.php
@@ -16,7 +16,7 @@ final class TwoFactorServiceProvider extends ServiceProvider
         $this->loadTranslationsFrom(__DIR__ . '/../lang', 'moonshine-two-factor');
 
 
-        $this->publishes([
+        $this->publishesMigrations([
             __DIR__ . '/../database/migrations' => database_path('migrations'),
         ]);
         

--- a/src/TwoFactorServiceProvider.php
+++ b/src/TwoFactorServiceProvider.php
@@ -13,7 +13,6 @@ final class TwoFactorServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->loadRoutesFrom(__DIR__ . '/../routes/two-factor.php');
-        $this->loadMigrationsFrom(__DIR__ . '/../database/migrations');
         $this->loadTranslationsFrom(__DIR__ . '/../lang', 'moonshine-two-factor');
 
 

--- a/src/TwoFactorServiceProvider.php
+++ b/src/TwoFactorServiceProvider.php
@@ -16,6 +16,11 @@ final class TwoFactorServiceProvider extends ServiceProvider
         $this->loadMigrationsFrom(__DIR__ . '/../database/migrations');
         $this->loadTranslationsFrom(__DIR__ . '/../lang', 'moonshine-two-factor');
 
+
+        $this->publishes([
+            __DIR__ . '/../database/migrations' => database_path('migrations'),
+        ]);
+        
         $this->publishes([
             __DIR__ . '/../lang' => $this->app->langPath('vendor/moonshine-two-factor'),
         ]);


### PR DESCRIPTION
В нашем проекте нет таблицы moonshine_users, поэтому в момент, когда ларавель ищет сервис провайдеры в пакетах и подгружает из них миграции - вылезает неустранимая ошибка. 
Надо дать возможность опубликовать миграцию и сменить название таблицы на кастомное